### PR TITLE
Fix ID for content injection

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
 <body>
     <h1>HireWho Plugin Development</h1>
     <p>Jobs loaded in div below</p>
-    <div id="hirewho-plugin" data-slug="ccclean" data-title="Job openings"></div>
+    <div id="whohire-plugin" data-slug="mainlineplumbingservice" data-title="Job openings"></div>
     <script src="./main.js"></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -2,84 +2,87 @@
  * Class to load HireWho jobs in a div for specific business
  */
 class HireWhoPlugin {
-    /**
-     * Initiate plugin
-     * @param {object} conf - contains business slug and optional HTML container ID
-     */
-    constructor(conf) {
-        // validate
-        if (!!conf) {
-            if (!conf) throw Error("HireWhoPlugin conf not available");
-            if (!conf.slug) throw Error("The business slug is needed for HireWho Plugin to load.");
-            if (!conf.container) container = "hirewho-plugin";
-            // set shared variables
-            this.slug = conf.slug;
-            this.container = document.getElementById(container);
-            this.title = conf.title || "Job openings";
-        } else {
-            this.container = document.getElementById("hirewho-plugin");
-            this.slug = this.container.getAttribute("data-slug");
-            this.title = this.container.getAttribute("data-title") || "Job openings";
-        }
-    }
+  /**
+   * Initiate plugin
+   * @param {object} conf - contains business slug and optional HTML container ID
+   */
+  constructor(conf) {
+    this.container =
+      document.getElementById("hirewho-plugin") ||
+      document.getElementById("whohire-plugin");
 
-    /**
-     * Main function to call to load jobs in a div
-     */
-    load() {
-        const url = `https://api.whohire.com/api/job/?slug=${this.slug}&publish=1`;
-        fetch(url)
-            .then((response) => response.json())
-            .then((data) => this._process(data));
-        this._insertStyles();
+    // validate
+    if (!!conf) {
+      if (!conf) throw Error("HireWhoPlugin conf not available");
+      if (!conf.slug)
+        throw Error("The business slug is needed for HireWho Plugin to load.");
+      // set shared variables
+      this.slug = conf.slug;
+      this.title = conf.title || "Job openings";
+      this.container = document.getElementById(conf.container);
+    } else {
+      this.slug = this.container.getAttribute("data-slug");
+      this.title = this.container.getAttribute("data-title") || "Job openings";
     }
+  }
 
-    /**
-     * Process jobs to show them on webpage
-     * @param {array} jobs - public jobs fetched from API
-     */
-    _process(jobs) {
-        if (!jobs.length) return;
-        let html = `<div id="hirewho-jobs">`;
-        html += `<h3>${this.title}</h3>`;
-        for (let i = 0; i < jobs.length; i++) {
-            const job = jobs[i];
-            const url = `https://api.whohire.com/job/${this.slug}/${job.id}`;
-            html += `<div class="hirewho-job">`;
-            html += `  <div>`;
-            html += `    <div class="job-title">${job.title}</div>`;
-            html += `    <div class="job-position">${job.position}</div>`;
-            html += `    <div class="job-location">${job.city}, ${job.state}</div>`;
-            html += `  </div>`;
-            html += `  <div>`;
-            html += `    <a href="${url}" target="_blank">View job</a>`;
-            html += `  </div>`;
-            html += "</div>";
-        }
-        html += `</div>`;
-        this.container.innerHTML = html;
+  /**
+   * Main function to call to load jobs in a div
+   */
+  load() {
+    const url = `https://api.whohire.com/api/job/?slug=${this.slug}&publish=1`;
+    fetch(url)
+      .then((response) => response.json())
+      .then((data) => this._process(data));
+    this._insertStyles();
+  }
+
+  /**
+   * Process jobs to show them on webpage
+   * @param {array} jobs - public jobs fetched from API
+   */
+  _process(jobs) {
+    if (!jobs.length) return;
+    let html = `<div id="hirewho-jobs">`;
+    html += `<h3>${this.title}</h3>`;
+    for (let i = 0; i < jobs.length; i++) {
+      const job = jobs[i];
+      const url = `https://api.whohire.com/job/${this.slug}/${job.id}`;
+      html += `<div class="hirewho-job">`;
+      html += `  <div>`;
+      html += `    <div class="job-title">${job.title}</div>`;
+      html += `    <div class="job-position">${job.position}</div>`;
+      html += `    <div class="job-location">${job.city}, ${job.state}</div>`;
+      html += `  </div>`;
+      html += `  <div>`;
+      html += `    <a href="${url}" target="_blank">View job</a>`;
+      html += `  </div>`;
+      html += "</div>";
     }
+    html += `</div>`;
+    this.container.innerHTML = html;
+  }
 
-    /**
-     * Insert CSS styles
-     */
-    _insertStyles() {
-        const style = document.createElement("style");
-        style.appendChild(document.createTextNode(""));
-        document.head.appendChild(style);
-        const { sheet } = style;
-        sheet.insertRule(
-            `
+  /**
+   * Insert CSS styles
+   */
+  _insertStyles() {
+    const style = document.createElement("style");
+    style.appendChild(document.createTextNode(""));
+    document.head.appendChild(style);
+    const { sheet } = style;
+    sheet.insertRule(
+      `
             #hirewho-jobs h3 {
                 text-align: center;
                 margin-bottom: 0;
                 font-size: 1.5rem;
             }
             `,
-            0
-        );
-        sheet.insertRule(
-            `
+      0
+    );
+    sheet.insertRule(
+      `
             .hirewho-job {
                 display: flex;
                 flex-direction: row;
@@ -88,35 +91,35 @@ class HireWhoPlugin {
                 padding: 1rem 0;
             }
         `,
-            0
-        );
-        sheet.insertRule(
-            `
+      0
+    );
+    sheet.insertRule(
+      `
             .hirewho-job:last-child {
                 border-bottom: none;
             }
         `,
-            0
-        );
-        sheet.insertRule(
-            `
+      0
+    );
+    sheet.insertRule(
+      `
             .job-title {
                 font-size: 1.2rem;
             }
         `,
-            0
-        );
-        sheet.insertRule(
-            `
+      0
+    );
+    sheet.insertRule(
+      `
             .job-position, .job-location {
                 color: #555;
                 padding-top: .25rem;
             }
         `,
-            0
-        );
-        sheet.insertRule(
-            `
+      0
+    );
+    sheet.insertRule(
+      `
             .hirewho-job a {
                 display: inline-block;
                 padding: .375rem .75rem;
@@ -126,9 +129,9 @@ class HireWhoPlugin {
                 border-radius: .25rem;
             }
         `,
-            0
-        );
-    }
+      0
+    );
+  }
 }
 
 // Fire plugin


### PR DESCRIPTION
Add support for hirewho-plugin and whohire-plugin as the container ID to receive content injection. Should work seamlessly for legacy and new users. Also fix logic for adding custom container ID. 